### PR TITLE
Changes to manually link devices instead of requiring child devices

### DIFF
--- a/hd-device/hd_app.groovy
+++ b/hd-device/hd_app.groovy
@@ -272,6 +272,7 @@ def updateLinkedDevices(boolean errorOnly=false) {
             d.setProjectID(getProjectId())
             d.setApiKey(getApiKey())
             d.setGoogleAccessToken(getGoogleAccessToken())
+            d.setAppID(getAppId())
             d.initialize()
         }
         

--- a/hd-device/hd_app.groovy
+++ b/hd-device/hd_app.groovy
@@ -78,7 +78,6 @@ def mainPage() {
             input 'appId', 'text', title: 'App ID', required: true, defaultValue: '', submitOnChange: true
         }
         section(header("Devices")) {
-            showChildren()
             input "linkedDevices", "device.HDDevice", title: "Linked Devices", multiple: true, required: false
         }
         section(header("Other")) {
@@ -86,17 +85,6 @@ def mainPage() {
         }
 
     }
-}
-
-def showChildren() {
-    def childList = getChildDevices()
-    childList.each {
-        String name = it.getName()
-        String label = it.getLabel()
-        logDebug("showChildren: ${name}, ${label}")
-        paragraph("${name} - ${label}")
-    }
-    input("addChildBtn", "button", title: "Add Child Device")
 }
 
 def showAuthorizeButton() {
@@ -171,29 +159,15 @@ def handleAuthRedirect() {
 
 def updated() {
     logDebug("updating")
-    createChildDevices()
     rescheduleLogin()
 
-    def childDevice = getChildDevice(state.deviceId)
-    childDevice?.initialize()
-    
     updateLinkedDevices()
 }
 
 def installed() {
     log.info "installed"
-    createChildDevices()
     // start app on Hub reboot?
     subscribe(location, 'systemStart', initialize)
-}
-
-def createChildDevices() {
-    if (isEmpty(state.deviceId)) {
-        state.deviceId = UUID.randomUUID().toString()
-    }
-    
-    if (!getChildDevice(state.deviceId))
-        addChildDevice('jpage4500', "HD Device", state.deviceId)
 }
 
 def uninstalled() {
@@ -298,20 +272,10 @@ def updateLinkedDevices(boolean errorOnly=false) {
             d.setProjectID(getProjectId())
             d.setApiKey(getApiKey())
             d.setGoogleAccessToken(getGoogleAccessToken())
+            d.initialize()
         }
         
         d.setError(getError())
-    }
-}
-
-def appButtonHandler(btn) {
-    logDebug("appButtonHandler: ${btn}")
-    switch (btn) {
-        case "addChildBtn":
-            logDebug("add child...")
-            String childId = UUID.randomUUID().toString()
-            addChildDevice('jpage4500', "HD+ Device", childId)
-            break;
     }
 }
 

--- a/hd-device/hd_app.groovy
+++ b/hd-device/hd_app.groovy
@@ -267,7 +267,7 @@ def handleLoginResponse(resp) {
 }
 
 def updateLinkedDevices(boolean errorOnly=false) {
-    linkedDevices.forEach {d -> 
+    linkedDevices?.forEach {d -> 
         if (!errorOnly) {
             d.setProjectID(getProjectId())
             d.setApiKey(getApiKey())

--- a/hd-device/hd_app.groovy
+++ b/hd-device/hd_app.groovy
@@ -79,7 +79,7 @@ def mainPage() {
         }
         section(header("Devices")) {
             showChildren()
-            input "linkedDevices", "capability.presenceSensor", title: "Linked Devices", multiple: true, required: false
+            input "linkedDevices", "device.HDDevice", title: "Linked Devices", multiple: true, required: false
         }
         section(header("Other")) {
             input name: "debugOutput", type: "bool", title: "Enable Debug Logging?", defaultValue: false, submitOnChange: true
@@ -193,7 +193,7 @@ def createChildDevices() {
     }
     
     if (!getChildDevice(state.deviceId))
-        addChildDevice('jpage4500', "HD+ Device", state.deviceId)
+        addChildDevice('jpage4500', "HD Device", state.deviceId)
 }
 
 def uninstalled() {

--- a/hd-device/hd_app.groovy
+++ b/hd-device/hd_app.groovy
@@ -79,6 +79,7 @@ def mainPage() {
         }
         section(header("Devices")) {
             showChildren()
+            input "linkedDevices", "capability.presenceSensor", title: "Linked Devices", multiple: true, required: false
         }
         section(header("Other")) {
             input name: "debugOutput", type: "bool", title: "Enable Debug Logging?", defaultValue: false, submitOnChange: true
@@ -175,6 +176,8 @@ def updated() {
 
     def childDevice = getChildDevice(state.deviceId)
     childDevice?.initialize()
+    
+    updateLinkedDevices()
 }
 
 def installed() {
@@ -188,7 +191,9 @@ def createChildDevices() {
     if (isEmpty(state.deviceId)) {
         state.deviceId = UUID.randomUUID().toString()
     }
-    addChildDevice('jpage4500', "HD+ Device", state.deviceId)
+    
+    if (!getChildDevice(state.deviceId))
+        addChildDevice('jpage4500', "HD+ Device", state.deviceId)
 }
 
 def uninstalled() {
@@ -278,6 +283,16 @@ def handleLoginResponse(resp) {
         state.googleRefreshToken = respJson.refresh_token
     }
     state.googleAccessToken = respJson.access_token
+    
+    updateLinkedDevices()
+}
+
+def updateLinkedDevices() {
+    linkedDevices.forEach {d -> 
+        d.setProjectID(getProjectId())
+        d.setApiKey(getApiKey())
+        d.setGoogleAccessToken(getGoogleAccessToken())
+    }
 }
 
 def appButtonHandler(btn) {

--- a/hd-device/hd_device.groovy
+++ b/hd-device/hd_device.groovy
@@ -52,6 +52,9 @@ metadata {
         capability "PresenceSensor"
         capability "PushableButton"
 
+        command('setProjectID', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the project ID']])
+        command('setApiKey', [[name: 'Set API key', type: 'STRING', description: 'HD+ will automatically set the API key']])
+        command('setGoogleAccessToken', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the access token']])
         command('setClientKey', [[name: 'Set Device FCM key', type: 'STRING', description: 'HD+ will automatically set the device FCM key']])
 
         //command('startMonitoring', [[name: 'Monitor Device Changes', type: 'STRING', description: 'HD+ will automatically call this']])
@@ -88,19 +91,48 @@ def logTokens() {
     updateTokens()
 }
 
+def setProjectID(String projectId) {
+    state.projectId = projectId
+}
+
+def setApiKey(String key) {
+    state.apiKey = key
+}
+
+def setGoogleAccessToken(String token) {
+    state.googleAccessToken = token
+}
+
+String getGoogleAccessToken() {
+    if (parent) return parent.getGoogleAccessToken()
+    return state.googleAccessToken
+}
+
+String getProjectID() {
+    if (parent) return parent.getProjectId()
+    return state.projectId
+}
+
+String getApiKey() {
+    if (parent) return parent.getApiKey()
+    return state.apiKey
+}
+
 def updateTokens() {
-    if (parent) {
-        // client side values required by HD+ to create a FCM token
-        def projectId = parent.getProjectId()
-        sendEvent(name: "projectId", value: projectId)
-        def apiKey = parent.getApiKey()
-        sendEvent(name: "apiKey", value: apiKey)
-        def appId = parent.getAppId()
-        sendEvent(name: "appId", value: appId)
-        if (isLogging) log.debug "updateTokens: proj:$projectId, token:$accessToken, appId:$appId"
-    } else {
+    // client side values required by HD+ to create a FCM token
+    def projectId = getProjectID()
+    if (projectId == null) {
         if (isLogging) log.debug "logTokens: no parent device!"
     }
+    else {
+        sendEvent(name: "projectId", value: projectId)
+        def apiKey = getApiKey()
+        sendEvent(name: "apiKey", value: apiKey)
+        def appId = parent?.getAppId()
+        sendEvent(name: "appId", value: appId)
+        if (isLogging) log.debug "updateTokens: proj:$projectId, token:$accessToken, appId:$appId"
+    }
+    
     updateStatus()
 }
 
@@ -136,12 +168,13 @@ def setClientKey(key) {
  * check if any config values are missing and set 'status' value
  */
 def updateStatus() {
-    if (!parent) {
+    def projectId = getProjectID()
+    def oauthToken = getGoogleAccessToken()
+    
+    if (!parent && !projectId) {
         sendEvent(name: "status", value: "ERROR: parent app not found")
         return
     }
-    def projectId = parent.getProjectId()
-    def oauthToken = parent.getGoogleAccessToken()
 
     if (isEmpty(projectId)) {
         sendEvent(name: "status", value: "ERROR: missing projectId")
@@ -158,9 +191,9 @@ def updateStatus() {
         return
     }
 
-    def error = parent.getError()
+    def error = parent?.getError()
     if (isEmpty(error)) {
-        sendEvent(name: "status", value: "READY")
+        sendEvent(name: "status", value: parent ? "READY" : "UNKNOWN")
     } else {
         sendEvent(name: "status", value: "ERROR: ${error}")
     }
@@ -268,8 +301,8 @@ void notifyVia(msgType, text) {
         sendEvent(name: "notificationText", value: text)
     }
 
-    def projectId = parent?.getProjectId()
-    def oauthToken = parent?.getGoogleAccessToken()
+    def projectId = getProjectID()
+    def oauthToken = getGoogleAccessToken()
     def clientKey = device.currentValue('clientKey')
     updateStatus()
 

--- a/hd-device/hd_device.groovy
+++ b/hd-device/hd_device.groovy
@@ -38,7 +38,7 @@ import hubitat.helper.InterfaceUtils
 
 metadata {
     definition(
-        name: "HD+ Device",
+        name: "HD Device",
         namespace: "jpage4500",
         author: "Joe Page",
         importUrl: "https://raw.githubusercontent.com/jpage4500/hubitat-drivers/master/hd-device/hd_device.groovy"

--- a/hd-device/hd_device.groovy
+++ b/hd-device/hd_device.groovy
@@ -54,6 +54,7 @@ metadata {
 
         command('setProjectID', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the project ID']])
         command('setApiKey', [[name: 'Set API key', type: 'STRING', description: 'HD+ will automatically set the API key']])
+        command('setAppID', [[name: 'Set app ID', type: 'STRING', description: 'HD+ will automatically set the app ID']])
         command('setGoogleAccessToken', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the access token']])
         command('setError', [[name: 'Set Error', type: 'STRING', description: 'HD+ will automatically set the error']])
         command('setClientKey', [[name: 'Set Device FCM key', type: 'STRING', description: 'HD+ will automatically set the device FCM key']])
@@ -79,6 +80,7 @@ metadata {
     // needed by Android client to generate a clientKey
     attribute "projectId", "string"
     attribute "apiKey", "string"
+    attribute "appId", "string"
     // set by Android client (FCM)
     attribute "clientKey", "string"
     // driver status: not configured, ready, error
@@ -107,6 +109,10 @@ def setError(String error) {
     state.error = error
 }
 
+def setAppID(String id) {
+    state.appID = id
+}
+
 String getGoogleAccessToken() {
     if (parent) return parent.getGoogleAccessToken()
     return state.googleAccessToken
@@ -127,6 +133,11 @@ String getError() {
     return state.error
 }
 
+String getAppID() {
+    if (parent) return parent.getAppId()
+    return state.appID
+}
+
 def updateTokens() {
     // client side values required by HD+ to create a FCM token
     def projectId = getProjectID()
@@ -137,7 +148,9 @@ def updateTokens() {
         sendEvent(name: "projectId", value: projectId)
         def apiKey = getApiKey()
         sendEvent(name: "apiKey", value: apiKey)
-        if (isLogging) log.debug "updateTokens: proj:${projectId}, token:${accessToken}"
+        def appId = getAppID()
+        sendEvent(name: "appId", value: appId)
+        if (isLogging) log.debug "updateTokens: proj:$projectId, token:$accessToken, appId:$appId"
     }
     
     updateStatus()
@@ -328,7 +341,7 @@ void notifyVia(msgType, text) {
 
     def headers = [
         "Authorization": "Bearer ${oauthToken}",
-        "Content-Type" : "application/json"
+        "Content-Type" : "application/json; UTF-8"
     ]
 
     def body = [

--- a/hd-device/hd_device.groovy
+++ b/hd-device/hd_device.groovy
@@ -55,6 +55,7 @@ metadata {
         command('setProjectID', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the project ID']])
         command('setApiKey', [[name: 'Set API key', type: 'STRING', description: 'HD+ will automatically set the API key']])
         command('setGoogleAccessToken', [[name: 'Set Project ID', type: 'STRING', description: 'HD+ will automatically set the access token']])
+        command('setError', [[name: 'Set Error', type: 'STRING', description: 'HD+ will automatically set the error']])
         command('setClientKey', [[name: 'Set Device FCM key', type: 'STRING', description: 'HD+ will automatically set the device FCM key']])
 
         //command('startMonitoring', [[name: 'Monitor Device Changes', type: 'STRING', description: 'HD+ will automatically call this']])
@@ -103,6 +104,10 @@ def setGoogleAccessToken(String token) {
     state.googleAccessToken = token
 }
 
+def setError(String error) {
+    state.error = error
+}
+
 String getGoogleAccessToken() {
     if (parent) return parent.getGoogleAccessToken()
     return state.googleAccessToken
@@ -116,6 +121,11 @@ String getProjectID() {
 String getApiKey() {
     if (parent) return parent.getApiKey()
     return state.apiKey
+}
+
+String getError() {
+    if (parent) return parent.getError()
+    return state.error
 }
 
 def updateTokens() {
@@ -191,7 +201,7 @@ def updateStatus() {
         return
     }
 
-    def error = parent?.getError()
+    def error = getError()
     if (isEmpty(error)) {
         sendEvent(name: "status", value: parent ? "READY" : "UNKNOWN")
     } else {

--- a/hd-device/hd_device.groovy
+++ b/hd-device/hd_device.groovy
@@ -78,7 +78,6 @@ metadata {
 
     // needed by Android client to generate a clientKey
     attribute "projectId", "string"
-    attribute "appId", "string"
     attribute "apiKey", "string"
     // set by Android client (FCM)
     attribute "clientKey", "string"
@@ -138,9 +137,7 @@ def updateTokens() {
         sendEvent(name: "projectId", value: projectId)
         def apiKey = getApiKey()
         sendEvent(name: "apiKey", value: apiKey)
-        def appId = parent?.getAppId()
-        sendEvent(name: "appId", value: appId)
-        if (isLogging) log.debug "updateTokens: proj:$projectId, token:$accessToken, appId:$appId"
+        if (isLogging) log.debug "updateTokens: proj:${projectId}, token:${accessToken}"
     }
     
     updateStatus()


### PR DESCRIPTION
I've removed the "Create child device" button and replaced it with a way to manually link devices to the companion app. It's backwards compatible -- all previously created child devices will continue to work.

Note that the Android app will need some changes, as I needed to change the name of the driver from "HD+ Device" to "HD Device" in order to get the device selection list to work properly.