### PR TITLE
Dynamic Polling

### DIFF
--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -274,7 +274,7 @@ boolean fetchLocations() {
     // state.memberInTransit = true
 
     if (settings.dynamicPolling) {
-        dynamicPolling(response)
+        dynamicPolling()
     }
 
     return true
@@ -582,7 +582,7 @@ void captureCookies(response) {
     }
 }
 
-void dynamicPolling(response) {
+void dynamicPolling() {
 
     // if (logEnable) log.trace("dynamicPolling - INFO: dynamicPolling:${dynamicPolling} || memberInTransit:${state.memberInTransit} || dynamicPollingActive:${state.dynamicPollingActive}")
 

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -101,8 +101,8 @@ def mainPage() {
         }
 
         section(header("Other Options")) {
-            input(name: "pollFreq", type: "enum", title: "Refresh Rate", required: true, defaultValue: "60", options: ['10': '10 seconds', '15': '15 seconds', '30': '30 seconds', '60': '1 minute', '300': '5 minutes', '0': 'Disabled'])
-            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling - Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've stopped.", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've arrived.")
+            input(name: "pollFreq", type: "enum", title: "Refresh Rate", required: true, defaultValue: "60", options: ['10': '10 seconds', '15': '15 seconds', '30': '30 seconds', '60': '1 minute', '180': '3 minutes', '300': '5 minutes', '0': 'Disabled'])
+            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling - Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've stopped.", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once still.")
             input(name: "logEnable", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Debug Logging", description: "Enable extra logging for debugging.")
             input("fetchLocationsBtn", "button", title: "Fetch Locations")
         }
@@ -577,7 +577,7 @@ void captureCookies(response) {
     response.getHeaders('Set-Cookie').each {
         def cookie = it.value.tokenize(';|,')[0]
         if (cookie) responseCookies << cookie
-        //if (logEnable) log.trace("captureCookies: ${cookie}")     //and logging the clean version
+        // if (logEnable) log.trace("captureCookies: ${cookie}")     //and logging the clean version
     }
     if (responseCookies) {
         state["cookies"] = responseCookies.join(";")

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -455,7 +455,7 @@ def refresh() {
 def scheduleUpdates() {
     unschedule()
 
-    Integer refreshSecs = 30
+    Integer refreshSecs = 60
     if (settings.dynamicPolling && state.memberInTransit && (settings.pollFreq.toInteger() > settings.dynamicPollFreq.toInteger())) {
         state.dynamicPollingActive = true
         refreshSecs = settings.dynamicPollFreq.toInteger()
@@ -463,28 +463,21 @@ def scheduleUpdates() {
         refreshSecs = settings.pollFreq.toInteger()
         state.dynamicPollingActive = false
     }
+    // add some randomness to this value (between 0 and 5 seconds)
+    Integer random = Math.abs(new Random().nextInt() % 5)
+    refreshSecs += random
 
-    // add some randomness to this value (between -5 and +5 seconds)
-    Integer randomSeconds = -5 + new Random().nextInt(11)
-    Integer finalSeconds = (refreshSecs + randomSeconds)
-    Integer finalMinutes = 0
-
-    while ( finalSeconds > 60 ) {
-        finalSeconds = (finalSeconds - 60)
-        finalMinutes++
-        // log.debug("scheduleUpdates WORKING - refreshSecs: ${refreshSecs} || minutesFinal: ${finalMinutes} || secondsFinal: ${finalSeconds}")
-    }
-
-    if (logEnable) log.debug("scheduleUpdates: pollFreq:${settings.pollFreq}, dynamicPollFreq:${settings.dynamicPollFreq}, randomSeconds:${randomSeconds}, finalSeconds:${finalSeconds}, finalMinutes:${finalMinutes}")
+    if (logEnable) log.debug("scheduleUpdates: refreshSecs:${refreshSecs}, pollFreq:${settings.pollFreq}, random:${random}, dynamicPollFreq: ${settings.dynamicPollFreq}")
 
     if (refreshSecs > 0 && refreshSecs < 60) {
         // seconds
-        schedule("0/${finalSeconds} * * * * ? *", handleTimerFired)
+        schedule("0/${refreshSecs} * * * * ? *", handleTimerFired)
     } else if (refreshSecs > 0) {
         // mins
-        schedule("0/${finalSeconds} */${finalMinutes} * * * ? *", handleTimerFired)
+        schedule("0 */${(refreshSecs / 60).toInteger()} * * * ? *", handleTimerFired)
     }
 }
+
 
 /**
  * called by timer

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -13,6 +13,7 @@ import java.net.http.HttpTimeoutException
  * - see discussion: https://community.hubitat.com/t/release-life360/118544
  *
  * Changes:
+ *  5.0.11 - 12/22/24 - bugfix when polling > 1 min
  *  5.0.10 - 12/21/24 - add some randomness
  *  5.0.9 - 12/19/24 - try a different API when hitting 403 error
  *  5.0.8 - 12/18/24 - added cookies found by @user3774

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -312,37 +312,36 @@ def fetchMemberLocation(memberId) {
                     state.message = "fetchMemberLocation: bad response:${response.status}, ${response.data}"
                 }
 
-
-
                 /* --------------------------- */
+                annoyingDebugging = false
 
-                if ( firstName == "Matt" ) { isDriving = 0 }
+                // HACK FOR TESTING DYNAMIC POLLING
+                // if ( firstName == "Matt" ) { isDriving = 0 }
 
                 if (dynamicPolling) {
                     
-                    if (logEnable) log.trace("---------------------------")
-                    if (logEnable) log.trace("DRIVING - INFO: dynamicPolling:${dynamicPolling} || isDrivingState:${state.isDrivingState} || dynamicPollingActive:${state.dynamicPollingActive} || isDrivingMember:${state.isDrivingMember}")
+                    if (annoyingDebugging) log.trace("---------------------------")
+                    if (annoyingDebugging) log.trace("DRIVING - INFO: dynamicPolling:${dynamicPolling} || isDrivingState:${state.isDrivingState} || dynamicPollingActive:${state.dynamicPollingActive} || isDrivingMember:${state.isDrivingMember}")
                     
                     
                     if (isDriving == 1 && ! state.isDrivingState && ! state.dynamicPollingActive) {
-                        if (logEnable) log.trace("DRIVING - SET DYNAMIC POLLING: ${firstName} isDriving ${isDriving}")
+                        if (logEnable) log.debug("DRIVING - SET DYNAMIC POLLING: ${firstName} isDriving ${isDriving}")
                         state.isDrivingState = true
                         state.isDrivingMember = memberId
                         scheduleUpdates()
                     } else if (isDriving == 1 && state.isDrivingState && state.dynamicPollingActive && state.isDrivingMember == memberId ) {
-                        if (logEnable) log.trace("DRIVING - ALREADY ACTIVE: ${firstName} isDriving ${isDriving}")
+                        if (annoyingDebugging) log.trace("DRIVING - ALREADY ACTIVE: ${firstName} isDriving ${isDriving}")
                     } else if (isDriving == 0 && state.isDrivingState && state.dynamicPollingActive && state.isDrivingMember == memberId ) {
-                        if (logEnable) log.trace("DRIVING - SET STANDARD POLLING: ${firstName} isDriving ${isDriving}")
+                        if (logEnable) log.debug("DRIVING - SET STANDARD POLLING: ${firstName} isDriving ${isDriving}")
                         state.isDrivingState = false
                         state.isDrivingMember = null
                         scheduleUpdates()
                     } else {
-                        if (logEnable) log.trace("DRIVING - DO NOTHING")
+                        // if (logEnable) log.trace("DRIVING - DO NOTHING")
                     }
                 }
-                if (logEnable) log.trace("---------------------------")
+                if (annoyingDebugging) log.trace("---------------------------")
                 /* --------------------------- */
-
 
         }
     } catch (e) {
@@ -451,12 +450,10 @@ def refresh() {
 }
 
 def scheduleUpdates() {
-
     unschedule()
 
     Integer refreshSecs = 30
     if (dynamicPolling && state.isDrivingState) {
-        if (logEnable) log.trace("scheduleUpdates - dynamicPolling: isDrivingState:${state.isDrivingState}")
         state.dynamicPollingActive = true
         refreshSecs = 10
     } else {

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -10,9 +10,10 @@ import java.net.http.HttpTimeoutException
  * ------------------------------------------------------------------------------------------------------------------------------
  * ** LIFE360+ Hubitat App **
  * Life360 companion app to track members' location in your circle
- * - see discussion: https://community.hubitat.com/t/release-life360/118544
+ * - Community discussion: https://community.hubitat.com/t/release-life360/118544
  *
  * Changes:
+ *  5.0.12 - 12/24/24 - Dynamic Polling (mpalermo73)
  *  5.0.12 - 12/24/24 - Improve Randomness (mpalermo73 / @user3774)
  *  5.0.11 - 12/22/24 - bugfix when polling > 1 min
  *  5.0.10 - 12/21/24 - add some randomness

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -103,8 +103,9 @@ def mainPage() {
         }
 
         section(header("Other Options")) {
-            input(name: "pollFreq", type: "enum", title: "Refresh Rate", required: true, defaultValue: "60", options: ['10': '10 seconds', '15': '15 seconds', '30': '30 seconds', '60': '1 minute', '180': '3 minutes', '300': '5 minutes', '0': 'Disabled'])
-            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling - Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've stopped.", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once still.")
+            input(name: "pollFreq", type: "enum", title: "Default Refresh Rate", required: true, defaultValue: "60", options: ['10': '10 seconds', '15': '15 seconds', '30': '30 seconds', '60': '1 minute', '180': '3 minutes', '300': '5 minutes', '0': 'Disabled'])
+            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling - Increase polling frequency to 'Dynamic Refesh Rate' when a member is in motion.  Polling returns to 'Default Refresh Rate' once they've stopped.", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once still.")
+            input(name: "dynamicPollFreq", type: "enum", title: "Dynamic Refesh Rate", required: false, defaultValue: "20", options: ['5': '5 seconds', '10': '10 seconds', '20': '20 seconds', '30': '30 seconds'])
             input(name: "logEnable", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Debug Logging", description: "Enable extra logging for debugging.")
             input("fetchLocationsBtn", "button", title: "Fetch Locations")
         }
@@ -458,9 +459,9 @@ def scheduleUpdates() {
     unschedule()
 
     Integer refreshSecs = 30
-    if (pollFreq.toInteger() > 20 && dynamicPolling && state.memberInTransit) {
+    if (settings.dynamicPolling && state.memberInTransit && (settings.pollFreq.toInteger() > settings.dynamicPollFreq.toInteger())) {
         state.dynamicPollingActive = true
-        refreshSecs = 20
+        refreshSecs = settings.dynamicPollFreq.toInteger()
     } else {
         refreshSecs = pollFreq.toInteger()
         state.dynamicPollingActive = false
@@ -469,7 +470,7 @@ def scheduleUpdates() {
     Integer random = Math.abs(new Random().nextInt() % 5)
     refreshSecs += random
 
-    if (logEnable) log.debug("scheduleUpdates: refreshSecs:$refreshSecs, pollFreq:$pollFreq, random:${random}")
+    if (logEnable) log.debug("scheduleUpdates: refreshSecs:$refreshSecs, pollFreq:$pollFreq, random:${random}, dynamicPollFreq: ${settings.dynamicPollFreq}")
     if (refreshSecs > 0 && refreshSecs < 60) {
         // seconds
         schedule("0/${refreshSecs} * * * * ? *", handleTimerFired)

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -336,10 +336,8 @@ def fetchMemberLocation(memberId) {
                 }
 
 
-                /* --------------------------- */
+                /* --------- DYNAMIC POLLING START --------- */
 
-
-                //if (annoyingDebugging) log.trace("--------- DYNAMIC POLLING START ---------")
                 if (dynamicPolling) {
                     
                     if (annoyingDebugging) log.trace("TRANSIT - INFO: dynamicPolling:${dynamicPolling} || inTransitState:${state.inTransitState} || dynamicPollingActive:${state.dynamicPollingActive} || inTransitMember:${state.inTransitMember}")
@@ -359,14 +357,12 @@ def fetchMemberLocation(memberId) {
                         state.inTransitMember = null
                         scheduleUpdates()
                     } else {
-                        if (logEnable) log.trace("TRANSIT - DO NOTHING")
+                        if (annoyingDebugging) log.trace("TRANSIT - DO NOTHING")
                     }
                 }
 
-                //if (annoyingDebugging) log.trace("--------- DYNAMIC POLLING END ---------")
-
-
-                /* --------------------------- */
+                /* --------- DYNAMIC POLLING END --------- */
+            
                 if (annoyingDebugging) log.trace("========= RESPONSE END - ${firstName} =========")
 
         }

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -102,7 +102,7 @@ def mainPage() {
 
         section(header("Other Options")) {
             input(name: "pollFreq", type: "enum", title: "Refresh Rate", required: true, defaultValue: "60", options: ['10': '10 seconds', '15': '15 seconds', '30': '30 seconds', '60': '1 minute', '300': '5 minutes', '0': 'Disabled'])
-            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once still.")
+            input(name: "dynamicPolling", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Dynamic Polling - Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've stopped.", description: "Increase polling frequency when a member is in motion.  Polling returns to 'Refresh Rate' once they've arrived.")
             input(name: "logEnable", type: "bool", defaultValue: "false", submitOnChange: "true", title: "Enable Debug Logging", description: "Enable extra logging for debugging.")
             input("fetchLocationsBtn", "button", title: "Fetch Locations")
         }

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -199,7 +199,7 @@ def fetchMembers() {
         log.debug("fetchMembers: circle not set")
         return;
     }
-    
+
     // https://api-cloudfront.life360.com/v3/circles/CIRCLE/members
     def params = [
         uri    : "https://api-cloudfront.life360.com",
@@ -213,7 +213,7 @@ def fetchMembers() {
         httpGet(params) {
             response ->
                 captureCookies(response)
-                // if (logEnable) log.debug("fetchMembers: ${response.data}")
+                //if (logEnable) log.debug("fetchMembers: ${response.data}")
                 if (response.status == 200) {
                     state.members = response.data?.members
                     state.message = null
@@ -275,17 +275,17 @@ def fetchMemberLocation(memberId) {
     def cookies = state["cookies"]
     if (cookies) {
         params["headers"]["Cookie"] = cookies
-        // if (logEnable) log.debug("fetchMemberLocation: cookie: ${cookies}")
+        //if (logEnable) log.debug("fetchMemberLocation: cookie: ${cookies}")
     }
 
     // set l360-etag value
     def tag = state["etag-${memberId}"]
     if (tag) {
         params["headers"]["If-None-Match"] = tag
-        // if (logEnable) log.debug("eTag header:  ${tag}")
+        //if (logEnable) log.debug("eTag header:  ${tag}")
     }
 
-    // if (logEnable) log.trace("fetchMemberLocation: member:${memberId}, tag:${tag}")
+    //if (logEnable) log.trace("fetchMemberLocation: member:${memberId}, tag:${tag}")
 
     try {
         httpGet(params) {
@@ -332,7 +332,7 @@ def fetchMemberLocation(memberId) {
 }
 
 def handleException(String tag, Exception e) {
-    // log.error("handleException: ${e}")
+    //log.error("handleException: ${e}")
     if (e instanceof HttpTimeoutException) {
         log.error("${tag}: EXCEPTION: ${e}")
         state.message = "TIMEOUT: ${tag}: ${e}"
@@ -513,7 +513,7 @@ def notifyChildDevice(memberId, memberObj) {
         def deviceWrapper = getChildDevice("${externalId}")
         if (deviceWrapper != null) {
             // send circle places and home to individual children
-            // if (logEnable) log.trace("notifyChildDevice: updating: ${memberObj.firstName}")
+            //if (logEnable) log.trace("notifyChildDevice: updating: ${memberObj.firstName}")
             boolean isChanged = deviceWrapper.generatePresenceEvent(memberObj, placesMap, home)
             // if (logEnable) log.trace("notifyChildDevice: DONE updating: ${memberObj.firstName}, isChanged:${isChanged}")
             if (isChanged) isAnyChanged = true
@@ -532,7 +532,7 @@ void captureCookies(response) {
     response.getHeaders('Set-Cookie').each {
         def cookie = it.value.tokenize(';|,')[0]
         if (cookie) responseCookies << cookie
-        // if (logEnable) log.trace("captureCookies: ${cookie}")     // and logging the clean version
+        //if (logEnable) log.trace("captureCookies: ${cookie}")     // and logging the clean version
     }
     if (responseCookies) {
         state["cookies"] = responseCookies.join(";")

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -575,9 +575,9 @@ void dynamicPolling(response) {
     state.memberInTransit = false
     
     state.members.each { member ->
-        if (member["location"].inTransit.toInteger() == 1) {
+        if (member["location"].inTransit.toInteger() == 1 && member["location"].speed.toInteger() > 1) {
             state.memberInTransit = true
-            log.trace("fetchMembers - ${member["firstName"]}: ${member["location"].inTransit} || ${member["location"].speed} || ${state.memberInTransit}")
+            log.trace("fetchMembers - ${member["firstName"]}: ${member["location"].inTransit} || ${member["location"].speed.toInteger()} || ${state.memberInTransit}")
         }
     }
 

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -199,9 +199,6 @@ def fetchMembers() {
         log.debug("fetchMembers: circle not set")
         return;
     }
-
-    state.memberInTransit = false
-
     
     // https://api-cloudfront.life360.com/v3/circles/CIRCLE/members
     def params = [
@@ -210,13 +207,13 @@ def fetchMembers() {
         headers: getHttpHeaders()
     ]
 
-//    log.debug("fetchMembers:")
+    if (logEnable) log.debug("fetchMembers:")
 
     try {
         httpGet(params) {
             response ->
                 captureCookies(response)
-                //if (logEnable) log.debug("fetchMembers: ${response.data}")
+                // if (logEnable) log.debug("fetchMembers: ${response.data}")
                 if (response.status == 200) {
                     state.members = response.data?.members
                     state.message = null
@@ -278,17 +275,17 @@ def fetchMemberLocation(memberId) {
     def cookies = state["cookies"]
     if (cookies) {
         params["headers"]["Cookie"] = cookies
-        //if (logEnable) log.debug("fetchMemberLocation: cookie: ${cookies}")
+        // if (logEnable) log.debug("fetchMemberLocation: cookie: ${cookies}")
     }
 
     // set l360-etag value
     def tag = state["etag-${memberId}"]
     if (tag) {
         params["headers"]["If-None-Match"] = tag
-        //if (logEnable) log.debug("eTag header:  ${tag}")
+        // if (logEnable) log.debug("eTag header:  ${tag}")
     }
 
-    //if (logEnable) log.trace("fetchMemberLocation: member:${memberId}, tag:${tag}")
+    // if (logEnable) log.trace("fetchMemberLocation: member:${memberId}, tag:${tag}")
 
     try {
         httpGet(params) {
@@ -335,7 +332,7 @@ def fetchMemberLocation(memberId) {
 }
 
 def handleException(String tag, Exception e) {
-    //log.error("handleException: ${e}")
+    // log.error("handleException: ${e}")
     if (e instanceof HttpTimeoutException) {
         log.error("${tag}: EXCEPTION: ${e}")
         state.message = "TIMEOUT: ${tag}: ${e}"
@@ -516,7 +513,7 @@ def notifyChildDevice(memberId, memberObj) {
         def deviceWrapper = getChildDevice("${externalId}")
         if (deviceWrapper != null) {
             // send circle places and home to individual children
-            //if (logEnable) log.trace("notifyChildDevice: updating: ${memberObj.firstName}")
+            // if (logEnable) log.trace("notifyChildDevice: updating: ${memberObj.firstName}")
             boolean isChanged = deviceWrapper.generatePresenceEvent(memberObj, placesMap, home)
             // if (logEnable) log.trace("notifyChildDevice: DONE updating: ${memberObj.firstName}, isChanged:${isChanged}")
             if (isChanged) isAnyChanged = true
@@ -535,7 +532,7 @@ void captureCookies(response) {
     response.getHeaders('Set-Cookie').each {
         def cookie = it.value.tokenize(';|,')[0]
         if (cookie) responseCookies << cookie
-        //if (logEnable) log.trace("captureCookies: ${cookie}")     //and logging the clean version
+        // if (logEnable) log.trace("captureCookies: ${cookie}")     // and logging the clean version
     }
     if (responseCookies) {
         state["cookies"] = responseCookies.join(";")
@@ -554,7 +551,7 @@ void dynamicPolling(response) {
     }
 
     // FOR TESTING DYNAMIC POLLING
-    //state.memberInTransit = true
+    // state.memberInTransit = true
 
     // if (logEnable) log.trace("dynamicPolling - INFO: dynamicPolling:${dynamicPolling} || memberInTransit:${state.memberInTransit} || dynamicPollingActive:${state.dynamicPollingActive}")
 

--- a/life360/life360_driver.groovy
+++ b/life360/life360_driver.groovy
@@ -6,24 +6,29 @@
 
 /**
  * ------------------------------------------------------------------------------------------------------------------------------
- * ** LIFE360+ Hubitat Driver **
+ * ** LIFE360+ Hubitat App **
  * Life360 companion app to track members' location in your circle
+ * - Community discussion: https://community.hubitat.com/t/release-life360/118544
  *
- * - see community discussion here: https://community.hubitat.com/t/release-life360/118544
- *
- *  Changes:
- *  5.0.9 - 12/19/24 - try a different API when hitting 403 error
- *  5.0.8 - 12/18/24 - added cookies found by @user3774
- *  5.0.7 - 12/11/24 - try to match Home Assistant
- *  5.0.6 - 12/05/24 - return to older API version (keeping eTag support)
- *  5.0.4 - 11/09/24 - use newer API
- *  5.0.0 - 11/01/24 - fix Life360+ support (requires manual entry of access_token)
+ * Changes:
+ *  5.0.12 - 12/24/24 - Dynamic Polling (mpalermo73)
+ *  5.0.12 - 12/24/24 - Improve Randomness (mpalermo73 / @user3774)
+ *  5.0.11 - 12/22/24 - bugfix when polling > 1 min
+ *  5.0.10 - 12/21/24 - add some randomness
+ *  5.0.9  - 12/19/24 - try a different API when hitting 403 error
+ *  5.0.8  - 12/18/24 - added cookies found by @user3774
+ *  5.0.7  - 12/11/24 - try to match Home Assistant
+ *  5.0.6  - 12/05/24 - return to older API version (keeping eTag support)
+ *  5.0.5  - 11/12/24 - support eTag for locations call
+ *  5.0.4  - 11/09/24 - use newer API
+ *  5.0.2  - 11/03/24 - restore webhook
+ *  5.0.0  - 11/01/24 - fix Life360+ support (requires manual entry of access_token)
+ *  4.0.0  - 02/08/24 - implement new Life360 API
  *
  * NOTE: This is a re-write of Life360+, which was just a continuation of "Life360 with States" -> https://community.hubitat.com/t/release-life360-with-states-track-all-attributes-with-app-and-driver-also-supports-rm4-and-dashboards/18274
  * - please see that thread for full history of this app/driver
- *
  * ------------------------------------------------------------------------------------------------------------------------------
- */
+ **/
 
 import java.text.SimpleDateFormat
 

--- a/life360/packageManifest.json
+++ b/life360/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Life360+",
   "author": "Joe Page",
-  "version": "5.0.12",
+  "version": "5.0.13",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2023-05-08",
   "communityLink": "https://community.hubitat.com/t/release-life360/118544",
-  "releaseNotes": "Improve Randomness (mpalermo73)",
+  "releaseNotes": "Dynamic Polling (mpalermo73)",
   "apps": [
     {
       "id": "5bae441c-e34c-4e7d-a4bc-fff19f53c2df",


### PR DESCRIPTION
This brings back an "auto" polling period rebranded as "Dynamic Polling".   The goal is to increase polling frequency when a Life360 member is moving (`inTransit`) and return to the user defined polling period when no motion is reported.

I also felt that Dynamic Polling could help with your thought of "randomizing" polling to help beat bot detectors.  WHile this isn't "randomizing", it does "randomly" change the existing polling period from time to time which may help.

I also stuck in a "3 minute" polling period option.  1 minute and less seemed overkill and 5 minutes felt too long now that we can have both overkill _and_ slow - dynamically! :wink:

![Screenshot_20241222_132037-1](https://github.com/user-attachments/assets/238f5be0-061c-4228-9662-6586e0713ec2)
