### PR TITLE
Improve Randomness

### DIFF
--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -438,23 +438,36 @@ def refresh() {
 def scheduleUpdates() {
     unschedule()
 
-    Integer refreshSecs = 30
+    Integer refreshSecs = 60
+    
     if (pollFreq == "auto") {
         // TODO: REMOVE
     } else {
-        refreshSecs = pollFreq.toInteger()
+        refreshSecs = settings.pollFreq.toInteger()
     }
-    // add some randomness to this value (between 0 and 5 seconds)
-    Integer random = Math.abs(new Random().nextInt() % 5)
-    refreshSecs += random
 
-    if (logEnable) log.debug("scheduleUpdates: refreshSecs:$refreshSecs, pollFreq:$pollFreq, random:${random}")
+    // add some randomness to this value (between -5 and +5 seconds)
+    Integer randomSeconds = -5 + new Random().nextInt(11)
+    Integer finalSeconds = (refreshSecs + randomSeconds)
+    Integer finalMinutes = 0
+
+    while ( finalSeconds > 60 ) {
+        finalSeconds = (finalSeconds - 60)
+        finalMinutes++
+        // log.debug("scheduleUpdates WORKING - refreshSecs: ${refreshSecs} || minutesFinal: ${finalMinutes} || secondsFinal: ${finalSeconds}")
+    }
+
+    // log.debug("scheduleUpdates FINAL - refreshSecs: ${refreshSecs} || minutesFinal: ${finalMinutes} || secondsFinal: ${finalSeconds}")
+
+
+    if (logEnable) log.debug("scheduleUpdates: refreshSecs:$refreshSecs, pollFreq:$pollFreq, randomSeconds:${randomSeconds}")
+
     if (refreshSecs > 0 && refreshSecs < 60) {
         // seconds
-        schedule("0/${refreshSecs} * * * * ? *", handleTimerFired)
+        schedule("0/${finalSeconds} * * * * ? *", handleTimerFired)
     } else if (refreshSecs > 0) {
         // mins
-        schedule("0 */${(refreshSecs / 60).toInteger()} * * * ? *", handleTimerFired)
+        schedule("0/${finalSeconds} */${finalMinutes} * * * ? *", handleTimerFired)
     }
 }
 


### PR DESCRIPTION
Improve schedule randomness
- positive AND negative variance
- works with polling periods of only seconds AND minutes


Screenshot shows two differnt schedule assignemsnts.  (startign a bottom, of course)
- FIRST: set `refreshSecs` to 180 seconds
  - add `-1` seconds of randomness for `179` seconds
  - loop ending on `179 == 2 minutes and 59 seconds
- SECOND: set `refreshSecs` to 30
  - add `-2` seconds of randomness for `28` seconds
  - no loop needed as 28 already less than 60.

![Screenshot_20241224_085046-1](https://github.com/user-attachments/assets/c33489a8-ce9a-4ac4-8788-0b8652b44c60)
