### PR TITLE
Fix typo in displayName for Life360+ app

### DIFF
--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -49,7 +49,7 @@ definition(
     singleInstance: true,
     importUrl: "https://raw.githubusercontent.com/jpage4500/hubitat-drivers/master/life360/life360_app.groovy",
     oauth: [
-        displayName: "Life360+"
+        displayName: "Life360+",
         displayLink: ""
     ]
 )


### PR DESCRIPTION
@jpage4500 

I am not sure how I missed this one tiny test...  I missed a `,`.  This is causing the app to not install.

:disappointed: 