### PR TITLE
User Found Bugs

### DIFF
--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -166,6 +166,8 @@ def mainPage() {
             input(name: "logRawPayload", type: "bool", defaultValue: false, submitOnChange: true, title: "Log Raw API Diagnostics", description: "Verbose. Logs sensitive data (GPS, partial token, cookies, payloads). Debug only — don't share resulting logs.")
             input(name: "logShowNames", type: "bool", defaultValue: true, submitOnChange: true, title: "Include Names and Places in Logs", description: "When on, logs show member/place/circle names. Turn off for privacy (UUIDs only) — useful when sharing logs for debugging.")
             input(name: "logShowMapsLink", type: "bool", defaultValue: true, submitOnChange: true, title: "Include Google Maps Link in Logs", description: "When a member moves, include a clickable Google Maps link to their coordinates in the info log. Turn off to keep coordinates out of logs.")
+            input(name: "logDrivingTransitions", type: "bool", defaultValue: true, submitOnChange: true, title: "Driving Logging")
+            paragraph "<small style='color:#666'>On: Each poll of a member in motion is logged.<br>Off: Only when a member starts or stops moving is logged.</small>"
             input(name: "logUnits", type: "enum", defaultValue: "life360", title: "Units (all members)",
                 description: "Units for speed and distance in logs and device attributes. Overrides each member device's own setting when set to anything other than 'Follow Life360 app'.",
                 options: ["life360": "Follow Life360 app (recommended)", "hubitat": "Follow Hubitat system (°F → miles, °C → km)", "imperial": "Miles / mph", "metric": "Kilometers / kph"])
@@ -577,6 +579,7 @@ boolean fetchLocations() {
     ctx.showMapsLink = (settings.logShowMapsLink != false)
     ctx.useMiles     = getUnitIsMiles()   // null = not yet known; driver falls back to its local pref
     ctx.logRawPayload = getLogRawPayload()
+    ctx.logDrivingTransitions = getLogDrivingTransitions()
 
     settings.users.each { memberId ->
         fetchMemberLocation(memberId, ctx)
@@ -906,6 +909,10 @@ boolean getLogRawPayload() {
     return settings.logRawPayload == true
 }
 
+boolean getLogDrivingTransitions() {
+    return settings.logDrivingTransitions != false
+}
+
 private String memberDisplayName(String memberId) {
     if (!showNamesInLogs()) return memberId
     return state.members?.find { it.id == memberId }?.firstName ?: memberId
@@ -1065,6 +1072,7 @@ def fastPollMember(data) {
     ctx.showMapsLink = (settings.logShowMapsLink != false)
     ctx.useMiles     = getUnitIsMiles()
     ctx.logRawPayload = getLogRawPayload()
+    ctx.logDrivingTransitions = getLogDrivingTransitions()
     fetchMemberLocation(memberId, ctx)
 }
 

--- a/life360/life360_app.groovy
+++ b/life360/life360_app.groovy
@@ -1195,8 +1195,10 @@ def handleCirclesPollResponse(response, data) {
 
     // heartbeat — fires on EVERY poll. Shows the count, any count change, and per-member
     // connection status (issues.disconnected) so the log proves polling is alive and healthy.
+    // Use state.members.size() for the display — the /circles API no longer returns memberCount.
+    int displayCount = state.members?.size() ?: 0
     String delta = countChanged ? " (${prevCount} → ${newCount})" : ""
-    log.info("heartbeat - ${circleName}: memberCount:${newCount}${delta} ${memberStatusSummary()}")
+    log.info("heartbeat - ${circleName}: memberCount:${displayCount}${delta} ${memberStatusSummary()}")
 }
 
 /**

--- a/life360/life360_driver.groovy
+++ b/life360/life360_driver.groovy
@@ -189,6 +189,7 @@ boolean generatePresenceEvent(member, thePlaces, home, Map ctx = null) {
     boolean showNames = (ctx?.showNames != null) ? ctx.showNames : { try { parent?.getShowNamesInLogs() != false } catch (ignored) { true } }()
     boolean showMapsLink = (ctx?.showMapsLink != null) ? ctx.showMapsLink : { try { parent?.getShowMapsLink() != false } catch (ignored) { true } }()
     boolean logRawPayload = (ctx?.logRawPayload != null) ? ctx.logRawPayload : { try { parent?.getLogRawPayload() == true } catch (ignored) { false } }()
+    boolean logEachPoll = (ctx?.logDrivingTransitions != null) ? ctx.logDrivingTransitions : { try { parent?.getLogDrivingTransitions() != false } catch (ignored) { true } }()
 
     // -- location --
     // round to 5 decimal places (~1m precision) — matches history storage and avoids spurious sub-meter jitter
@@ -227,6 +228,8 @@ boolean generatePresenceEvent(member, thePlaces, home, Map ctx = null) {
     // -- previous values (used for address history and location history) --
     Double prevLatitude = device.currentValue('latitude')
     Double prevLongitude = device.currentValue('longitude')
+    Boolean prevIsDriving = device.currentValue('isDriving') == 'true'
+    Boolean prevInTransit = device.currentValue('inTransit') == 'true'
 
     if (logRawPayload) log.trace("generatePresenceEvent: location payload: ${location}")
 
@@ -328,12 +331,23 @@ boolean generatePresenceEvent(member, thePlaces, home, Map ctx = null) {
         isDriving = (speedUnits >= drivingThresholdD)
     }
 
-    if (inTransit || isDriving) {
-        String suffix = showMapsLink ? " — <a href='https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}' target='_blank'>Google Maps link</a>" : ""
-        log.info("${displayMember(memberFirstName, showNames)}: moving @ ${speedUnits} ${useMiles ? 'mph' : 'kph'}${suffix}")
+    String suffix = showMapsLink ? " — <a href='https://www.google.com/maps/search/?api=1&query=${latitude},${longitude}' target='_blank'>Google Maps link</a>" : ""
+    boolean moving = inTransit || isDriving
+    boolean prevMoving = prevInTransit || prevIsDriving
+    if (logEachPoll) {
+        // default on: log every poll when moving
+        if (moving) {
+            log.info("${displayMember(memberFirstName, showNames)}: moving @ ${speedUnits} ${useMiles ? 'mph' : 'kph'}${suffix}")
+        }
+    } else {
+        // quiet mode: only log start/stop of any motion (driving or transit)
+        if (moving && !prevMoving) {
+            log.info("${displayMember(memberFirstName, showNames)}: started moving${suffix}")
+        } else if (!moving && prevMoving) {
+            log.info("${displayMember(memberFirstName, showNames)}: stopped moving${suffix}")
+        }
     }
-    // Only worth logging when a threshold override is in play — otherwise this just restates
-    // the RAW L360 flags (and the "moving @" line already shows the speed). §5.4 trust-the-payload.
+    // extra debug detail only when debug logging is on
     if (thresholdActive && logEnable) log.debug("MOTION ${displayMember(memberFirstName, showNames)}: " +
         "speedUnits:${speedUnits} inTransit:${inTransit} isDriving:${isDriving} (threshold override)")
 

--- a/life360/packageManifest.json
+++ b/life360/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Life360+",
   "author": "Joe Page",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2023-05-08",
   "communityLink": "https://community.hubitat.com/t/release-life360/118544",
-  "releaseNotes": "fix captureCookiesAsync throws MissingMethodException on tokenize()",
+  "releaseNotes": "fix heartbeat log always showing memberCount:0 when using newer /circles API endpoint",
   "apps": [
     {
       "id": "5bae441c-e34c-4e7d-a4bc-fff19f53c2df",

--- a/life360/packageManifest.json
+++ b/life360/packageManifest.json
@@ -5,7 +5,7 @@
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2023-05-08",
   "communityLink": "https://community.hubitat.com/t/release-life360/118544",
-  "releaseNotes": "fix heartbeat log always showing memberCount:0 when using newer /circles API endpoint",
+  "releaseNotes": "Fixed heartbeat log always showing memberCount:0 when using newer /circles API endpoint. Also added an option to turn off the per-poll driver update when  member is in motion. When off, the log will only print starting and ending travel events. This should help reduce log spam for those who have a lot of members in motion.",
   "apps": [
     {
       "id": "5bae441c-e34c-4e7d-a4bc-fff19f53c2df",


### PR DESCRIPTION
Bump version to 5.2.2.

---

### Fix heartbeat log always showing memberCount:0 on newer /circles API
The newer /circles API endpoint no longer returns memberCount, so the heartbeat log was always displaying 0. Use state.members.size() for the display value only; change-detection logic is left untouched.

