### PR TITLE
- url encoding, set videoWeb attribute

### DIFF
--- a/go2rtc/CLAUDE.md
+++ b/go2rtc/CLAUDE.md
@@ -42,6 +42,10 @@ App setting overrides: `map_<cleanBase>_<role>` enum per group.
   stream. `take()` bumps cache-buster; `publishUrls()` does not.
 - **Multi-quality RTSP**: each role gets a fixed attribute (`videoMain`, `videoSub`, ...). `video` = active quality
   (default `main`). `selectStream(role)` command switches `video`. `streamRoles` JSON attribute for apps/debug.
+  Stream names are **path-encoded** in RTSP urls (`pathEnc`: space → `%20`, not `+`) — a raw space yields an
+  invalid URI that many RTSP clients reject.
+- **`videoWeb`**: go2rtc HTTP player page (`{server}/stream.html?src=NAME`, on the 1984 API port) for the active
+  stream — follows `selectStream` like `video`. For viewers that want the browser player, not raw RTSP.
 - **VideoCapture** is declared only because the user asked for it; Hubitat's def is useless for live cameras.
 - Server URL / host / RTSP port / creds are pushed app → parent (`setServer`) → child (`configure`). Creds in
   child's `state`; embedded in RTSP urls but NOT in `image`/`snapshotUrl`.

--- a/go2rtc/go2rtc-driver.groovy
+++ b/go2rtc/go2rtc-driver.groovy
@@ -9,7 +9,8 @@
  *     refresh is actually requested (take() / refresh() / the app's poll timer). Nothing is downloaded to the
  *     hub - the dashboard / browser fetches the frame straight from go2rtc.
  *   - VideoCapture: Hubitat has no useful stream definition here, so RTSP URLs are published in custom
- *     attributes: video (active quality), videoMain, videoSub, videoExt, etc.
+ *     attributes: video (active quality), videoMain, videoSub, videoExt, etc. videoWeb holds the go2rtc
+ *     HTTP player URL ({server}/stream.html?src=NAME) for the active quality.
  *   - selectStream(role): switch the active "video" attribute between configured qualities.
  *
  * Server URL / host / RTSP port / credentials are pushed from the app via the parent's configure() call.
@@ -44,6 +45,7 @@ metadata {
         attribute 'videoHigh', 'string'
         attribute 'videoSd', 'string'
         attribute 'videoHd', 'string'
+        attribute 'videoWeb', 'string'        // go2rtc HTTP player URL for active stream ({server}/stream.html?src=NAME)
         attribute 'snapshotUrl', 'string'     // live still-image URL, no cache-buster
         attribute 'streamName', 'string'      // primary (main) go2rtc stream name
         attribute 'streamRoles', 'string'     // JSON map of role -> stream name
@@ -117,7 +119,14 @@ private Map streamRoles() {
 private String rtspUrl(String name) {
     if (isEmpty(name)) return null
     String creds = isEmpty(state.username) ? '' : "${state.username}:${state.password ?: ''}@"
-    return "rtsp://${creds}${host()}:${rtspPort()}/${name}"
+    // name is a URL path segment - encode it (a raw space etc. yields an invalid URI many RTSP clients reject)
+    return "rtsp://${creds}${host()}:${rtspPort()}/${pathEnc(name)}"
+}
+
+// go2rtc HTTP player page for a stream ({server}/stream.html?src=NAME) - opens in a browser / desktop viewer
+private String webUrl(String name) {
+    if (isEmpty(name) || isEmpty(serverBase())) return null
+    return "${serverBase()}/stream.html?src=${urlEnc(name)}"
 }
 
 private String pickDefaultRole(Map roles) {
@@ -150,6 +159,7 @@ private void publishUrls() {
     if (primary) updateDataValue('streamName', primary)
     sendEventIfChanged('streamName', primary)
     sendEventIfChanged('video', rtspUrl(activeName))
+    sendEventIfChanged('videoWeb', webUrl(activeName))
 
     if (serverBase() && primary) {
         sendEventIfChanged('snapshotUrl', snapshotUrl(primary))
@@ -313,6 +323,8 @@ private String maskUrl(String url) {
 }
 
 private String urlEnc(String s) { return java.net.URLEncoder.encode(s ?: '', 'UTF-8') }
+// encode a stream name for use as a URL PATH segment: spaces -> %20 (not '+', which a path treats literally)
+private String pathEnc(String s) { return urlEnc(s).replace('+', '%20') }
 private String nowStr() { new Date().format('yyyy-MM-dd HH:mm:ss') }
 private boolean isEmpty(def v) { return v == null || (v instanceof String && v.trim().isEmpty()) }
 

--- a/go2rtc/packageManifest.json
+++ b/go2rtc/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "go2rtc",
   "author": "Joe Page",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-07-15",
   "communityLink": "https://community.hubitat.com/t/release-hd-android-dashboard/41674",
-  "releaseNotes": "Stream mapping UI only saves real manual overrides; auto-grouping updates when stream names change",
+  "releaseNotes": "- URL encode video attribute for device names with spaces\n- Add a new videoWeb attribute which exposes the go2rtc HTTP stream URL",
   "apps": [
     {
       "id": "f0f6fdb2-08fb-4078-9abb-58fa6278df15",


### PR DESCRIPTION
1. Fix the encoding bug — URL-encode the stream name in rtspUrl() so it becomes rtsp://192.168.0.160:8554/Attic%20Camera

2. Also expose the go2rtc HTTP stream URL — add an attribute (e.g. videoWeb → http://<host>:1984/stream.html?src=<name>) so apps that prefer the web player have it.