### PR TITLE
- chromecast changes

### DIFF
--- a/google-chromecast-plus/CLAUDE.md
+++ b/google-chromecast-plus/CLAUDE.md
@@ -9,6 +9,35 @@ Three files that must be deployed **together** (they call each other's methods; 
 missing method during `createChild`): `google-chromecast-plus-app.groovy`,
 `google-chromecast-plus-parent-driver.groovy`, `google-chromecast-plus-driver.groovy`.
 
+## Discovery & the device list (app)
+
+`scanMdns()` **merges** into `state.discovered` and nothing auto-prunes it, by design: a device that's merely
+powered off also drops out of the hub's mDNS cache, and `syncChildren()` deletes any child whose candidate is
+gone — so auto-expiry would delete real devices. The checkbox is the only remover, and it is **checked by
+default** (`isSelected` returns true unless the setting is explicitly `false`), so anything still in
+`state.discovered` gets its child re-created on every Done.
+
+That's what produced the reported "ghost devices keep coming back" (2026-08-20): the DNI is derived from
+`uuid ?: mac ?: ip`, and a factory reset, or editing/deleting a speaker or display **group** in Google Home,
+mints a new `deviceId` → a new DNI, leaving the old entry listed and re-created forever.
+
+Fix: `scanMdns()` stamps `lastSeenMs` on every entry it sees; `isStale()` flags an mDNS candidate missing for
+`STALE_MS` (15 min ≈ 3 missed scans) and `deviceRow()` replaces its status line with *"not seen in mDNS since
+… — uncheck to remove"*. Unchecking such a row makes `syncChildren()` drop it from `state.discovered` (plus
+its `sel_` setting and the `state.candidates` cache) so the row is gone for good. Rules that fall out of it:
+
+- A device **still visible in mDNS** but unchecked stays listed (unchecked) — that's how you keep a real
+  Chromecast out of Hubitat without it reappearing.
+- A **manual** entry never goes stale (`source == 'manual'`), but unchecking one now also removes it from
+  `state.manual` — otherwise it stayed a candidate and the child came back on the next Done.
+- Entries saved before `lastSeenMs` existed read as stale; harmless, since `mainPage` scans before rendering
+  and anything live is re-stamped.
+
+A [user PR](https://raw.githubusercontent.com/tweas/HubitatPublic/refs/heads/master/Chromecast%2BRemoveStaleDevices)
+proposed a separate "Potentially Stale Devices" section with its own `remove_*` checkboxes. Not merged: it put
+two opposite-polarity checkboxes on the same device (stale entries stay in `candidates`, so they appeared in
+both lists) and duplicated the whole mDNS read + DNI derivation in a second `getCurrentMdnsDevices()`.
+
 ## How TTS works (current)
 
 `speak()` / `playText()` → `announce()` → Hubitat `textToSpeech()` (Amazon Polly here; returns an **MP3**,

--- a/google-chromecast-plus/CLAUDE.md
+++ b/google-chromecast-plus/CLAUDE.md
@@ -76,6 +76,27 @@ Design points, all deliberate:
   because it was the first line, ahead of that function's `sec < 1` early return.
 - The parent driver's group `speak()` forwards raw text to each child's `speak()`, so groups are covered too.
 
+## Parent-device broadcast
+
+`broadcast(text, volume)` fans one announcement out to every child (and the `SpeechSynthesis` `speak()`
+overloads route here, so the parent can be picked as a single Speak/Notification target).
+
+`broadcastIdle(text, volume)` (added 2026-08-21, from a user request) is the same fan-out filtered by
+`isIdleChild()` — announce only where nothing is playing, so a broadcast doesn't talk over someone's music.
+Two things the naive `status == "stopped"` filter gets wrong, both handled:
+
+- **`markOffline()` and `initialize()` also set `status` to `stopped`**, so an unreachable device reads as
+  idle and the announcement gets queued on a device that can't play it. `isIdleChild()` also requires
+  `connectionStatus` to be outside `[offline, disconnected]` (`idle` = never connected yet, still allowed).
+- Log the filtered count as `N of M device(s)` — otherwise a broadcast that reached nobody looks identical to
+  one that reached everybody.
+
+Known caveat, not worth machinery: `status` only flips to `playing` when the child's LOAD actually reaches
+PLAYING, so a device asked to speak a second ago still reads idle and back-to-back broadcasts can double up
+on it. The real "speaking now" flag is `state.ttsActive` in the child, which the parent can't read without a
+new child method — deliberately avoided (a parent-only update would then break every `broadcastIdle` call
+with a missing-method error; attributes are always readable regardless of version skew).
+
 ## TTS issues & status
 
 ### Chirps around announcements — FIXED

--- a/google-chromecast-plus/CLAUDE.md
+++ b/google-chromecast-plus/CLAUDE.md
@@ -50,6 +50,32 @@ afterward (mode `restore`/`resume`). `playTrack()` / `playMedia()` play a URL di
   skipped when the delay is 0 or the text already contains `<break`/`<speak>`.
 - There is **no separate silence clip and no swap** anymore — the announcement is one media item.
 
+### SSML in TTS text (brace alias)
+
+TTS text may contain SSML (`<break>`, `<prosody>`, …) and it works from the device page's **Play Text**. It
+does **not** work from Rule Machine: RM sanitizes its text fields and strips everything between `<` and `>`
+(HTML entities and `&#60;`/`&#62;` are stripped along with it), so the markup never reaches the driver.
+
+Fix (reported 2026-08-21): `unescapeSsml()` in the driver, called from `announce()` **before** `withLeadIn()`,
+accepts two bracket-free spellings and converts them back —
+
+- `Hello {break time="2s"/} World` (brace alias, the one that survives RM)
+- `Hello &lt;break time="2s"/&gt; World` (also `&#60;`/`&#62;`, for callers that only encode)
+
+Design points, all deliberate:
+
+- **Only real SSML tag names** convert (`SSML_ALIAS_RX` whitelist: break, speak, prosody, emphasis, say-as,
+  sub, phoneme, voice, audio, lang, mark, p, s, w). A blanket `{`→`<` swap — the original user hack — means a
+  `%variable%` expanding to text with braces turns into garbage markup.
+- **Case-sensitive.** SSML is XML: `<BREAK/>` is rejected by the engine and the whole announcement is lost
+  (`textToSpeech` returns no uri), whereas leaving `{BREAK/}` as literal text makes the typo audible.
+- **Void tags get closed** (`SSML_VOID_RX`): `{break time="2s"}` / `<break time="2s">` → `<break time="2s"/>`,
+  since an unclosed void tag also loses the announcement.
+- Runs **before** `withLeadIn()` so its "caller already supplied SSML" check sees the converted `<break` and
+  doesn't prepend a second pause. The original hack lived *inside* `withLeadIn` — it happened to work only
+  because it was the first line, ahead of that function's `sec < 1` early return.
+- The parent driver's group `speak()` forwards raw text to each child's `speak()`, so groups are covered too.
+
 ## TTS issues & status
 
 ### Chirps around announcements — FIXED

--- a/google-chromecast-plus/google-chromecast-plus-app.groovy
+++ b/google-chromecast-plus/google-chromecast-plus-app.groovy
@@ -39,6 +39,9 @@ preferences {
 @Field static final String PARENT_DRIVER = 'Google Chromecast+ Parent'
 @Field static final String MDNS_SERVICE = '_googlecast._tcp'
 @Field static final Integer DEFAULT_PORT = 8009
+// how long a device can be missing from the hub's mDNS cache before its row is flagged as stale
+// (scanMdns runs every 5 min, so this is ~3 missed scans)
+@Field static final Long STALE_MS = 15 * 60 * 1000
 
 // ----------------------------------------------------------------------------
 // lifecycle
@@ -219,7 +222,8 @@ def scanMdns() {
                     String deviceType = castDeviceType(txt.ca)
                     String dni = "GoogleChromecastPlus-${cleanId((uuid ?: mac ?: ip).toString())}"
                     disc[dni] = [ip: ip, port: port, name: name, uuid: uuid, mac: mac?.toString(), model: model,
-                                 deviceType: deviceType, statusText: txt.rs, castVersion: txt.ve]
+                                 deviceType: deviceType, statusText: txt.rs, castVersion: txt.ve,
+                                 lastSeenMs: now()]     // drives isStale() - entries are never auto-pruned
                 }
             } catch (ex) {
                 logWarn "scanMdns: skipping ${mac}: ${ex.message}"
@@ -235,7 +239,7 @@ def scanMdns() {
 Map discoverDevices() {
     scanMdns()
     Map candidates = [:]
-    (state.discovered ?: [:]).each { dni, d -> candidates[dni] = [ip: d.ip, port: d.port, name: d.name, uuid: d.uuid, model: d.model, deviceType: d.deviceType, statusText: d.statusText, source: 'mdns'] }
+    (state.discovered ?: [:]).each { dni, d -> candidates[dni] = [ip: d.ip, port: d.port, name: d.name, uuid: d.uuid, model: d.model, deviceType: d.deviceType, statusText: d.statusText, lastSeenMs: d.lastSeenMs, source: 'mdns'] }
     (state.manual ?: []).each { m ->
         candidates[manualDni(m.ip)] = [ip: m.ip, port: (m.port ?: DEFAULT_PORT), name: (m.name ?: m.ip), uuid: null, source: 'manual']
     }
@@ -284,6 +288,18 @@ private String castDeviceType(caValue) {
     return 'unknown'
 }
 
+// A candidate that has dropped out of the hub's mDNS cache. Discovery only ever merges into
+// state.discovered, so a device that was factory-reset or renamed (new deviceId -> new DNI), or a
+// speaker/display group edited or deleted in Google Home (groups get a fresh deviceId), leaves its old
+// entry behind forever - and since the checkbox defaults to checked, syncChildren keeps re-creating the
+// child. Stale rows are only *flagged* here, never auto-removed: a device that is merely powered off also
+// falls out of mDNS, and dropping it from the candidates would delete its child device. Entries saved
+// before lastSeenMs existed read as stale, which is safe - anything live is re-stamped by the scan
+// mainPage runs before rendering.
+private boolean isStale(Map d) {
+    return d?.source == 'mdns' && (!d.lastSeenMs || (now() - (d.lastSeenMs as Long)) > STALE_MS)
+}
+
 // one selectable row: name/ip/model + a live-status line pulled from the created child (if any)
 private String deviceRow(Map d, child) {
     String s = "<b>${d.name}</b> &mdash; ${d.ip}"
@@ -310,6 +326,11 @@ private String deviceRow(Map d, child) {
                 if (since) extra += " since ${clockTime(since)}"
             }
         }
+    }
+    // a row that's gone from mDNS is the one worth unchecking, so say that instead of "offline"
+    if (isStale(d)) {
+        String seen = d.lastSeenMs ? " since ${clockTime(new Date(d.lastSeenMs as Long))}" : ''
+        extra = "not seen in mDNS${seen} &mdash; uncheck to remove"
     }
     return s + "<br><span style='font-size:smaller;color:#666'>${extra}</span>"
 }
@@ -340,8 +361,32 @@ private void syncChildren() {
     def parent = getParentDevice()
     if (!parent) { logError 'syncChildren: no parent device'; return }
     Set wanted = [] as Set
+    Set gone = [] as Set        // unchecked AND not re-discoverable -> forget the entry, not just the child
+    Map disc = state.discovered ?: [:]
+    List manual = state.manual ?: []
     (state.candidates ?: [:]).each { dni, d ->
-        if (isSelected(dni)) { parent.createChild(dni, d.name, d.ip, "${d.port}", d.uuid, d.deviceType); wanted << dni }
+        if (isSelected(dni)) {
+            parent.createChild(dni, d.name, d.ip, "${d.port}", d.uuid, d.deviceType); wanted << dni
+        } else if (d.source == 'manual') {
+            // nothing re-discovers a manual entry, so unchecking has to drop the entry itself - otherwise
+            // it stays a candidate and (with the checkbox defaulting to checked) comes back on the next Done
+            manual = manual.findAll { manualDni(it.ip) != dni }
+            gone << dni
+        } else if (isStale(d)) {
+            // unchecked and gone from mDNS -> forget it so the row disappears for good. a device still
+            // visible in mDNS stays listed (unchecked), as it always has - that's how you keep a real
+            // Chromecast out of Hubitat without it reappearing.
+            disc.remove(dni)
+            gone << dni
+        }
+    }
+    state.discovered = disc
+    state.manual = manual
+    if (gone) {
+        // prune the render-time candidate cache too, and don't leave orphan checkbox settings behind
+        state.candidates = (state.candidates ?: [:]).findAll { !gone.contains(it.key) }
+        gone.each { app.removeSetting("sel_${cleanId(it)}") }
+        logInfo "syncChildren: forgot ${gone.size()} device(s): ${gone.join(', ')}"
     }
     parent.getChildDevices().each { child ->
         if (!wanted.contains(child.deviceNetworkId)) parent.deleteChild(child.deviceNetworkId)

--- a/google-chromecast-plus/google-chromecast-plus-app.groovy
+++ b/google-chromecast-plus/google-chromecast-plus-app.groovy
@@ -155,6 +155,7 @@ def mainPage() {
             input name: 'refreshInterval', type: 'number', title: 'Status refresh interval (seconds)', defaultValue: 60, range: '10..3600', submitOnChange: true
             input name: 'debugOutput', type: 'bool', title: 'Enable debug logging (auto-off after 24h)', defaultValue: false, submitOnChange: true
             paragraph "<small>Announcement volume and lead-in delay are set per device &mdash; open a Chromecast device to change them.</small>"
+            paragraph '<small>Rule Machine strips &lt; and &gt; out of its text fields, so SSML typed in a rule never reaches the device. Write it with braces instead &mdash; <b>Hello {break time="2s"/} World</b> &mdash; and the driver converts it back.</small>'
         }
         section {
             if (settings.debugOutput == true && state.debugDisableMs) {

--- a/google-chromecast-plus/google-chromecast-plus-driver.groovy
+++ b/google-chromecast-plus/google-chromecast-plus-driver.groovy
@@ -11,9 +11,12 @@
  *   - CHILD  (role=child, one per Chromecast):  owns a socket, full protocol, TTS/media/transport/status.
  *
  * Fixes the built-in integration's headline bugs: the 2-second TTS cutoff (answer heartbeat PINGs
- * synchronously; gate the restore on real MEDIA_STATUS transitions) and first-word clipping (play a short
- * hub-hosted silent lead-in that wakes the speaker's amp / warms the receiver, held briefly - longer on
- * displays like the Nest Hub - before the announcement loads).
+ * synchronously; gate the restore on real MEDIA_STATUS transitions) and first-word clipping (bake the
+ * lead-in pause into the TTS clip itself as an SSML <break> - per-device "Lead-in delay" preference - so the
+ * announcement is one media item with no hub-hosted pre-roll to swap in).
+ *
+ * TTS text may contain SSML. Callers that sanitize HTML (Rule Machine) strip everything between < and >, so
+ * a brace spelling is accepted too:  Hello {break time="2s"/} World  ==  Hello <break time="2s"/> World.
  * ------------------------------------------------------------------------------------------------------------------------------
  **/
 
@@ -33,6 +36,16 @@ import java.util.concurrent.atomic.AtomicInteger
 @Field static final String RECV    = "receiver-0"
 @Field static final String APP_DMR = "CC1AD845"          // Default Media Receiver
 @Field static final Integer CAST_PORT = 8009
+
+// -- TTS text (see unescapeSsml) --
+// {tag ...} spelling of an SSML tag, for callers that strip angle brackets. Only real SSML tag names are
+// converted, so ordinary braces (or a Hubitat %variable% that expands to some) are spoken as typed.
+// Case-sensitive on purpose: SSML is XML, so <BREAK/> would be rejected by the TTS engine and lose the whole
+// announcement - leaving "{BREAK/}" as literal text instead makes the typo audible rather than silent.
+@Field static final String SSML_ALIAS_RX = '\\{(/?(?:break|speak|prosody|emphasis|say-as|sub|phoneme|voice|audio|lang|mark|p|s|w)\\b[^{}]*)\\}'
+// a void tag written without its closing slash - <break time="2s"> - is invalid SSML and can fail the whole
+// announcement, so close it rather than pass it through
+@Field static final String SSML_VOID_RX = '<(break|mark)([^<>/]*)>'
 
 
 // per-device, cross-callback state (parse/socketStatus/scheduled jobs can run on different threads)
@@ -112,6 +125,21 @@ private Integer getPort()  { return (getDataValue("port") ?: "${CAST_PORT}") as 
 private boolean isKeepAlive() { return settings.keepAlive != false }
 // lead-in delay (seconds, 0 = none): per-device preference driving an SSML pause prepended to the TTS text.
 private Integer leadInSec() { return Math.max(0, Math.min(5, (settings.leadInDelay ?: 0) as Integer)) }
+
+// Rule Machine (and anything else that sanitizes HTML in a text field) strips everything between < and >,
+// so SSML typed into a rule action never reaches the driver - the same text works from the device page.
+// Accept two bracket-free spellings and turn them back into real markup:
+//   Hello {break time="2s"/} World      (brace alias)
+//   Hello &lt;break time="2s"/&gt; World   (HTML entities, also &#60;/&#62;)
+// Runs before withLeadIn so its "caller already supplied SSML" check sees the converted tags, and before
+// textToSpeech so the engine gets valid SSML. Text with no braces/entities/tags is returned untouched.
+private String unescapeSsml(String text) {
+    if (!text || !(text.contains('{') || text.contains('&') || text.contains('<'))) return text
+    String out = text.replaceAll('&(?:lt|#0*60);', '<').replaceAll('&(?:gt|#0*62);', '>')
+    out = out.replaceAll(SSML_ALIAS_RX, '<$1>').replaceAll(SSML_VOID_RX, '<$1$2/>')
+    if (out != text) logDebug("SSML: \"${text}\" -> \"${out}\"")
+    return out
+}
 
 // Prepend an SSML pause so the TTS clip itself opens with silence - a slow-to-wake device (Nest Hub) clips
 // into that silence instead of the first words, and it plays as one media item (no separate pre-roll to swap).
@@ -254,7 +282,7 @@ def disconnect()     { logInfo "disconnect"; state.pendingActions = []; closeSoc
 private void announce(String text, volume, String mode, String voice = null) {
     if (isEmpty(text)) return
     logInfo "TTS: \"${text}\" (mode=${mode}${volume != null ? ", volume=${volume}" : ""}${voice ? ", voice=${voice}" : ""})"
-    String ttsText = withLeadIn(text)
+    String ttsText = withLeadIn(unescapeSsml(text))
     Map tts = voice ? textToSpeech(ttsText, voice) : textToSpeech(ttsText)
     if (!tts?.uri) { logError "announce: textToSpeech returned no uri for '${text}'"; return }
     enqueue([type: "announce", stage: "app", url: tts.uri, dur: (tts.duration ?: 0),

--- a/google-chromecast-plus/google-chromecast-plus-parent-driver.groovy
+++ b/google-chromecast-plus/google-chromecast-plus-parent-driver.groovy
@@ -6,7 +6,8 @@
  * it aggregates its child Chromecast devices (deviceCount / playingCount / summary) and provides the
  * management hooks the app calls (create/delete children, broadcast the refresh interval + debug flag).
  * The one user-facing feature is broadcast/speak: a single announcement fanned out to every child
- * Chromecast at once. Individual Chromecast control still lives in each child device (driver
+ * Chromecast at once - or only to the idle ones (broadcastIdle), so a broadcast doesn't talk over whatever
+ * is already playing. Individual Chromecast control still lives in each child device (driver
  * "Google Chromecast+").
  * ------------------------------------------------------------------------------------------------------------------------------
  **/
@@ -35,6 +36,12 @@ metadata {
         // capability's bare speak(text)); volume blank = each device keeps its own setting
         command "broadcast", [
             [name: "Message*", type: "STRING", description: "text to speak on every Chromecast"],
+            [name: "Volume", type: "NUMBER", description: "0-100, blank = leave each device's current volume"]
+        ]
+
+        // same fan-out, but skips any Chromecast that's currently playing something (or unreachable)
+        command "broadcastIdle", [
+            [name: "Message*", type: "STRING", description: "text to speak on every idle (not playing) Chromecast"],
             [name: "Volume", type: "NUMBER", description: "0-100, blank = leave each device's current volume"]
         ]
     }
@@ -103,11 +110,10 @@ def setDebug(flag) {
 
 
 // ============================================================================
-// broadcast (fan one announcement out to every child at once)
+// broadcast (fan one announcement out to every child, or only to the idle ones)
 // ============================================================================
 // SpeechSynthesis capability - each child's own speak() handles TTS, per-device volume & lead-in,
-// and restores whatever it was playing afterward. speak() returns quickly (the child defers the
-// blocking TLS connect), so looping over children here doesn't stall.
+// and restores whatever it was playing afterward.
 def speak(text)                { broadcast(text, null) }
 def speak(text, volume)        { broadcast(text, volume) }
 def speak(text, volume, voice) { broadcast(text, volume, voice) }
@@ -115,8 +121,32 @@ def speak(text, volume, voice) { broadcast(text, volume, voice) }
 // custom command: play <text> on every child Chromecast at once
 def broadcast(text, volume = null, voice = null) {
     if (isEmpty(text)) { logWarn "broadcast: empty message, ignoring"; return }
+    speakTo(getChildDevices(), text, volume, voice, "broadcast")
+}
+
+// custom command: same, but skip whatever is busy - announce only where nothing is playing, so a broadcast
+// doesn't talk over someone's music or podcast (those devices simply don't get this announcement).
+def broadcastIdle(text, volume = null, voice = null) {
+    if (isEmpty(text)) { logWarn "broadcastIdle: empty message, ignoring"; return }
     def kids = getChildDevices()
-    logInfo "broadcast: '${text}'${volume != null ? " @${volume}" : ""} -> ${kids.size()} device(s)"
+    speakTo(kids.findAll { isIdleChild(it) }, text, volume, voice, "broadcastIdle", kids.size())
+}
+
+// "idle" = nothing playing AND reachable. status is the child's mapped Cast playerState
+// (playing/paused/buffering/stopped), but markOffline and initialize also park it at "stopped" - so without
+// the connectionStatus check an unreachable device counts as idle and the announcement is queued on a device
+// that can't play it. Caveat: a child asked to speak a moment ago still reads "stopped" until its LOAD
+// actually reaches PLAYING, so two broadcasts fired back-to-back can still double up on the same device.
+private boolean isIdleChild(child) {
+    return child.currentValue("status") == "stopped" &&
+           !(child.currentValue("connectionStatus") in ["offline", "disconnected"])
+}
+
+// shared fan-out for broadcast/broadcastIdle. Each child's speak() returns quickly (it defers the blocking
+// TLS connect), so looping here doesn't stall even with an unreachable device in the list.
+private void speakTo(kids, text, volume, voice, String what, Integer total = null) {
+    String scope = (total != null && total != kids.size()) ? "${kids.size()} of ${total}" : "${kids.size()}"
+    logInfo "${what}: '${text}'${volume != null ? " @${volume}" : ""} -> ${scope} device(s)"
     kids.each { child ->
         if (voice != null)       child.speak(text, volume, voice)
         else if (volume != null) child.speak(text, volume)

--- a/google-chromecast-plus/packageManifest.json
+++ b/google-chromecast-plus/packageManifest.json
@@ -5,7 +5,7 @@
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-07-05",
   "communityLink": "https://community.hubitat.com/t/release-hd-android-dashboard/41674",
-  "releaseNotes": "- flag devices that haven't been seen in 5 minutes as 'stale'\n- support modified SSML for use in Rule Manager (use {} instead of <>)",
+  "releaseNotes": "- flag devices that haven't been seen in 5 minutes as 'stale'\n- support modified SSML for use in Rule Manager (use {} instead of <>)\n- add broadcastIdle() function",
   "apps": [
     {
       "id": "8f2ca643-8da9-4001-bea6-e0310ab85f8a",

--- a/google-chromecast-plus/packageManifest.json
+++ b/google-chromecast-plus/packageManifest.json
@@ -5,7 +5,7 @@
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-07-05",
   "communityLink": "https://community.hubitat.com/t/release-hd-android-dashboard/41674",
-  "releaseNotes": "- flag devices that haven't been seen in 5 minutes as 'stale'",
+  "releaseNotes": "- flag devices that haven't been seen in 5 minutes as 'stale'\n- support modified SSML for use in Rule Manager (use {} instead of <>)",
   "apps": [
     {
       "id": "8f2ca643-8da9-4001-bea6-e0310ab85f8a",

--- a/google-chromecast-plus/packageManifest.json
+++ b/google-chromecast-plus/packageManifest.json
@@ -1,11 +1,11 @@
 {
   "packageName": "Google Chromecast+",
   "author": "Joe Page",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2026-07-05",
   "communityLink": "https://community.hubitat.com/t/release-hd-android-dashboard/41674",
-  "releaseNotes": "- better logic for playTrackAndResume",
+  "releaseNotes": "- flag devices that haven't been seen in 5 minutes as 'stale'",
   "apps": [
     {
       "id": "8f2ca643-8da9-4001-bea6-e0310ab85f8a",


### PR DESCRIPTION
- flag devices that haven't been seen in 5 minutes as 'stale'
- support modified SSML for use in Rule Manager (use {} instead of <>)
- add broadcastIdle() function